### PR TITLE
[BIO-6581] added configurable default extent for search map

### DIFF
--- a/ckanext/dbca/dbca_dataset.yaml
+++ b/ckanext/dbca/dbca_dataset.yaml
@@ -264,7 +264,7 @@ dataset_fields:
   display_snippet: dbca_spatial.html
   choices_helper: spatial_choices
   form_placeholder: Paste a valid GeoJSON geometry
-  help_text: To select a predefined area from IBRA (bioregions and subregions), IMCRA, LGA, or DBCA's Conservation Estate, start typing the name below. To select Western Australia, begin typing "Western Australia". Alternatively, paste a GeoJSON Polygon or Multipolygon geometry below.  Please visit <a>LINK TBC</a> for a full list of prepopulated regions.
+  help_text: To select a predefined area from IBRA (bioregions and subregions), IMCRA, LGA, or DBCA's Conservation Estate, start typing the name below. To select Western Australia, begin typing "Western Australia". Alternatively, paste a GeoJSON Polygon or Multipolygon geometry below.  Please visit <a href="https://bio.wa.gov.au/knowledge/documentation/spatial-metadata">Spatial Metadata</a> for a full list of prepopulated regions.
   help_allow_html: true
   form_attrs:
     class:

--- a/ckanext/dbca/helpers.py
+++ b/ckanext/dbca/helpers.py
@@ -1,4 +1,5 @@
 import ckan.model as model
+import ckan.plugins.toolkit as toolkit
 import json
 import os
 
@@ -56,8 +57,13 @@ def spatial_choices(field):
     return choice_list
 
 
+def get_default_map_coordinates_config():
+    return toolkit.config.get('ckanext.dbca.default_map_coordinates', None)
+
+
 def get_helpers():
     return {
         "extract_emails_from_package": extract_emails_from_package,
         "spatial_choices": spatial_choices,
+        "get_default_map_coordinates_config": get_default_map_coordinates_config,
     }

--- a/ckanext/dbca/logic/validators.py
+++ b/ckanext/dbca/logic/validators.py
@@ -1,4 +1,5 @@
 import ckan.plugins.toolkit as tk
+import geojson
 import logging
 import datetime
 import pytz
@@ -43,9 +44,27 @@ def dbca_embargo_date_package_visibility(key, data, errors, context):
         errors[key].append(tk._(f"Only private datasets can be embargoed"))
 
 
+def dbca_validate_geojson(value):
+    """
+    Validate the format of GeoJSON.
+    """
+    if len(value) > 0:
+        try:
+            # Load JSON string to geojson object.
+            geojson_obj = geojson.loads(value)
+        except:
+            raise tk.Invalid('Not a valid JSON string.')
+
+        if geojson_obj.__class__.__name__ != 'Polygon':
+            raise tk.Invalid('GeoJSON Polygon is needed.')
+
+    return value
+
+
 def get_validators():
     return {
         "dbca_required": dbca_required,
         "dbca_embargo_date_validator": dbca_embargo_date_validator,
         "dbca_embargo_date_package_visibility": dbca_embargo_date_package_visibility,
+        "dbca_validate_geojson": dbca_validate_geojson,
     }

--- a/ckanext/dbca/plugin.py
+++ b/ckanext/dbca/plugin.py
@@ -19,6 +19,16 @@ class DbcaPlugin(plugins.SingletonPlugin):
 
     # IConfigurer
 
+    def update_config_schema(self, schema):
+        ignore_missing = toolkit.get_validator('ignore_missing')
+        dbca_validate_geojson = toolkit.get_validator('dbca_validate_geojson')
+
+        schema.update({
+            'ckanext.dbca.default_map_coordinates': [ignore_missing, dbca_validate_geojson]
+        })
+
+        return schema
+
     def update_config(self, config_):
         toolkit.add_template_directory(config_, "templates")
         toolkit.add_public_directory(config_, "public")

--- a/ckanext/dbca/templates/admin/config.html
+++ b/ckanext/dbca/templates/admin/config.html
@@ -1,0 +1,16 @@
+{% ckan_extends %}
+
+{% import 'macros/form.html' as form %}
+
+{% block admin_form %}
+  {{ super() }}
+  {{ 
+    form.textarea(
+    'ckanext.dbca.default_map_coordinates',
+    id='field-ckanext.dbca.default_map_coordinates',
+    label=_('Default map coordinates'),
+    placeholder='GeoJSON polygon',
+    value=data['ckanext.dbca.default_map_coordinates'],
+    error=errors['ckanext.dbca.default_map_coordinates']) 
+  }}
+{% endblock %}

--- a/ckanext/dbca/templates/package/search.html
+++ b/ckanext/dbca/templates/package/search.html
@@ -1,6 +1,7 @@
 {% ckan_extends %}
 
 {% block secondary_content %}
-  {% snippet "spatial/snippets/spatial_query.html" %}
+  {% set default_extent = h.get_default_map_coordinates_config() %}
+  {% snippet "spatial/snippets/spatial_query.html", default_extent=default_extent %}
   {{ super() }}
 {% endblock %}


### PR DESCRIPTION
https://dev.azure.com/BIO-WA/CKAN%20Mod/_workitems/edit/6581
https://dev.azure.com/BIO-WA/CKAN%20Mod/_workitems/edit/6513/

changes

- added a textarea in config form
- added validator for above field
- implemement the value to be used in default_extent prop
- updated link on the help text for dataset

![image](https://github.com/dbca-wa/ckanext-dbca/assets/1538818/d8616b76-e9ee-42c2-afa6-68367fb79d3e)
![image](https://github.com/dbca-wa/ckanext-dbca/assets/1538818/2516a120-5dc8-4590-a3f0-977dffca1ac5)
![image](https://github.com/dbca-wa/ckanext-dbca/assets/1538818/fbc864bb-fd9c-4c75-abdd-d02d7ad117fa)
