### PR TITLE
Release: ORM rollback middleware and collection notice sidebar

### DIFF
--- a/ckanext/dbca/plugin.py
+++ b/ckanext/dbca/plugin.py
@@ -1,11 +1,17 @@
+import logging
+
+import ckan.model as model
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
+from ckan.plugins.interfaces import IMiddleware
 
 from ckanext.dbca import cli, views, helpers
 from ckanext.dbca.logic import action, validators
 from ckanext.doi.interfaces import IDoi
 from ckanext.dbca.db_log_handler import configure_logging
 from ckanext.dbca.model import dbca_logs
+
+log = logging.getLogger(__name__)
 
 
 class DbcaPlugin(plugins.SingletonPlugin):
@@ -16,6 +22,7 @@ class DbcaPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IValidators)
     plugins.implements(IDoi, inherit=True)
+    plugins.implements(IMiddleware)
 
     # IConfigurer
 
@@ -35,6 +42,37 @@ class DbcaPlugin(plugins.SingletonPlugin):
         toolkit.add_resource("assets", "ckanext_dbca")
         if dbca_logs.exists():
             configure_logging()
+
+    # IMiddleware
+    def make_middleware(self, app, config):
+        """Make the middleware for the app."""
+        @app.after_request
+        def _rollback_orm_after_server_error(response):
+            # Error handlers (e.g. for InternalServerError)
+            # Roll back on 5xx so a failed ORM transaction is not left open.
+            if response is not None and response.status_code >= 500:
+                try:
+                    model.Session.rollback()
+                except Exception:
+                    log.exception(
+                        "ckanext-dbca: could not roll back ORM after 5xx response"
+                    )
+            return response
+
+        @app.teardown_request
+        def _rollback_orm_on_unhandled_exception(exc):
+            # Unhandled exceptions (e.g. for RuntimeError)
+            # Roll back on unhandled exceptions so a failed ORM transaction is not left open.
+            if exc is None:
+                return
+            try:
+                model.Session.rollback()
+            except Exception:
+                log.exception(
+                    "ckanext-dbca: could not roll back ORM after unhandled request error"
+                )
+
+        return app
 
     # IActions
 

--- a/ckanext/dbca/templates/error_document_template.html
+++ b/ckanext/dbca/templates/error_document_template.html
@@ -1,0 +1,32 @@
+{# Error pages only: do not use the default header (page.html -> include header.html),
+   which triggers build_nav_main / ckanext-pages and can fail when the DB is unhealthy.
+   Markup matches core CKAN header regions (account-masthead + masthead) without includes. #}
+{% ckan_extends %}
+
+{% block header %}
+  <header class="masthead" role="banner">
+    <div class="container">
+      <nav class="navbar navbar-expand-lg navbar-light">
+        <hgroup class="{{ g.header_class }} navbar-left">
+          {% block error_header_logo %}
+            {% if g.site_logo %}
+              <a class="logo" href="/" title="{{ g.site_title|default('') }}">
+                <img
+                  src="{{ h.url_for_static_or_external(g.site_logo) }}"
+                  alt="{{ g.site_title|default(_('Data catalogue'), true) }}"
+                />
+              </a>
+            {% else %}
+              <h1 class="m-0">
+                <a href="/">{{ g.site_title|default(_('Data catalogue'), true) }}</a>
+              </h1>
+              {% if g.site_description %}
+                <h2 class="h5 text-muted mt-1 mb-0">{{ g.site_description }}</h2>
+              {% endif %}
+            {% endif %}
+          {% endblock %}
+        </hgroup>
+      </nav>
+    </div>
+  </header>
+{% endblock %}

--- a/ckanext/dbca/templates/package/base_form_page.html
+++ b/ckanext/dbca/templates/package/base_form_page.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+
+{% block secondary_content %}
+    {{ super() }}
+    {% snippet "snippets/collection_notice_sidebar.html" %}
+{% endblock %}

--- a/ckanext/dbca/templates/package/edit.html
+++ b/ckanext/dbca/templates/package/edit.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+
+{% block secondary_content %}
+    {{ super() }}
+    {% snippet "snippets/collection_notice_sidebar.html" %}
+{% endblock %}

--- a/ckanext/dbca/templates/snippets/collection_notice_sidebar.html
+++ b/ckanext/dbca/templates/snippets/collection_notice_sidebar.html
@@ -1,0 +1,8 @@
+<section class="module module-narrow module-shallow collection-notice-sidebar">
+    <div class="module-content">
+        <p>{{ _("By using this system, you acknowledge DBCA's collection and use of personal information") }}</p>
+        <p class="action">
+            <a class="btn btn-default" href="/pages/collection-notice-disclaimer">{{ _("Collection Notice disclaimer") }}</a>
+        </p>
+    </div>
+</section>

--- a/ckanext/dbca/templates/user/login.html
+++ b/ckanext/dbca/templates/user/login.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+
+{% block help_forgotten %}
+    {{ super() }}
+    {% snippet "snippets/collection_notice_sidebar.html" %}
+{% endblock %}


### PR DESCRIPTION
## Summary

- **ORM rollback middleware** ([SD-8386](https://servicedesk.salsadigital.com.au/a/tickets/8386)): Implements `IMiddleware` in `DbcaPlugin` to roll back dangling ORM transactions on 5xx responses and unhandled exceptions, preventing stale DB sessions from blocking subsequent requests.
- **Error page resilience** ([SD-8386](https://servicedesk.salsadigital.com.au/a/tickets/8386)): Adds a custom `error_document_template.html` that renders a minimal header without triggering `build_nav_main` / `ckanext-pages`, avoiding failures when the DB is unhealthy.
- **Collection notice sidebar** ([SD-8379](https://servicedesk.salsadigital.com.au/a/tickets/8379)): Adds a reusable `collection_notice_sidebar.html` snippet displaying DBCA's personal information collection notice with a link to the disclaimer page. Injected into the package create/edit forms and the login page sidebar.

## Changes

| File | Change |
|------|--------|
| `ckanext/dbca/plugin.py` | Adds `IMiddleware`, `make_middleware` with `after_request` + `teardown_request` ORM rollback hooks |
| `templates/error_document_template.html` | Custom error header that avoids DB-dependent nav includes |
| `templates/snippets/collection_notice_sidebar.html` | New collection notice snippet |
| `templates/package/base_form_page.html` | Injects collection notice into secondary content |
| `templates/package/edit.html` | Injects collection notice into secondary content |
| `templates/user/login.html` | Injects collection notice into help/forgotten block |